### PR TITLE
Update crypt_ltc_mp_descriptor.c

### DIFF
--- a/src/misc/crypt/crypt_ltc_mp_descriptor.c
+++ b/src/misc/crypt/crypt_ltc_mp_descriptor.c
@@ -19,9 +19,3 @@ ltc_math_descriptor ltc_mp = { 0 };
 // workaround for nasty osx linker bug
 // see https://github.com/ruslo/hunter/pull/877#issuecomment-319945897 for details
 // ifdefed because "= {}" casues compile errors on windows
-#ifdef __APPLE__
-    ltc_math_descriptor ltc_mp = {};
-#else
-    ltc_math_descriptor ltc_mp;
-#endif
-


### PR DESCRIPTION
Delete workaround for horrible linker issue on macos